### PR TITLE
Use Lexical prec for % disambiguation

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -60,7 +60,7 @@ module.exports = grammar({
     $._PERLY_BRACE_OPEN,
     $._HASHBRACK,
     $._PERLY_PERCENT,
-    $._MULOP,
+    $._MULOPOly,
     /* immediates */
     $._quotelike_end,
     $._q_string_content,
@@ -477,7 +477,7 @@ module.exports = grammar({
 
     scalar:   $ => seq('$',  $._indirob),
     array:    $ => seq('@',  $._indirob),
-    hash:     $ => seq($._PERLY_PERCENT, $._indirob),
+    hash:     $ => seq(token(prec(2, '%')), $._indirob),
     arraylen: $ => seq('$#', $._indirob),
     // perly.y calls this `star`
     glob:     $ => seq('*',  $._indirob),
@@ -529,6 +529,7 @@ module.exports = grammar({
     _BITANDOP: $ => '&', // TODO: also &. when enabled
     _SHIFTOP: $ => choice('<<', '>>'),
     _ADDOP: $ => choice('+', '-', '.'),
+    _MULOP: $ => choice('*', '/', '%', 'x'),
     /* _MULOP is external; is roughly choice('*', '/', '%', 'x')
      * but with logic to distinguish '%' here from %hash
      */

--- a/grammar.js
+++ b/grammar.js
@@ -59,8 +59,6 @@ module.exports = grammar({
     $._PERLY_SEMICOLON,
     $._PERLY_BRACE_OPEN,
     $._HASHBRACK,
-    $._PERLY_PERCENT,
-    $._MULOPOly,
     /* immediates */
     $._quotelike_end,
     $._q_string_content,

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -25,8 +25,6 @@ enum TokenType {
   PERLY_SEMICOLON,
   PERLY_BRACE_OPEN,
   TOKEN_HASHBRACK,
-  PERLY_PERCENT,
-  TOKEN_MULOP,
   /* immediates */
   TOKEN_QUOTELIKE_END,
   TOKEN_Q_STRING_CONTENT,
@@ -227,7 +225,7 @@ bool tree_sitter_perl_external_scanner_scan(
       break;
     }
 
-  if(allow_identalike || valid_symbols[PERLY_SEMICOLON] || valid_symbols[TOKEN_MULOP]);
+  if(allow_identalike || valid_symbols[PERLY_SEMICOLON]);
     skip_whitespace(lexer);
 
   c = lexer->lookahead;
@@ -257,50 +255,6 @@ bool tree_sitter_perl_external_scanner_scan(
     }
     else {
       TOKEN(TOKEN_HASHBRACK);
-    }
-  }
-
-  /* Check PERLY_PERCENT before TOKEN_MULOP so that e.g.
-   *    keys %hash
-   * parses as    FUNC1OP (HASH = PERLY_PERCENT BAREWORD)
-   * rather than  FUNC1OP  MULOP  BAREWORD
-   */
-  if(valid_symbols[PERLY_PERCENT]) {
-    if(c == '%') {
-      lexer->advance(lexer, false);
-      TOKEN(PERLY_PERCENT);
-    }
-  }
-
-  if(valid_symbols[TOKEN_MULOP]) {
-    switch(c) {
-      case '*':
-        lexer->advance(lexer, false);
-        if(lexer->lookahead == '*')
-          /* `**` is not a MULOP */
-          return false;
-        lexer->advance(lexer, false);
-
-        TOKEN(TOKEN_MULOP);
-
-      case '/':
-        lexer->advance(lexer, false);
-        if(lexer->lookahead == '/')
-          /* `//` is not a MULOP */
-          return false;
-        lexer->advance(lexer, false);
-
-        TOKEN(TOKEN_MULOP);
-
-      case 'x':
-        lexer->advance(lexer, false);
-
-        TOKEN(TOKEN_MULOP);
-
-      case '%':
-        lexer->advance(lexer, false);
-
-        TOKEN(TOKEN_MULOP);
     }
   }
 


### PR DESCRIPTION
- trial: lexical precedence for PERLY_PERCENT
- cleanup: remove scanner handling for PERLY_PERCENT and co
